### PR TITLE
Remove rounding bound to integers

### DIFF
--- a/Sources/GridLayoutMath/LayoutPositioning.swift
+++ b/Sources/GridLayoutMath/LayoutPositioning.swift
@@ -237,7 +237,6 @@ extension LayoutPositioning {
       newBounds.size[keyPath: flow.size(.fixed)] = fixedTrackSize
       newBounds.origin[keyPath: flow.cgPointIndex(.growing)] = growingPosition
       newBounds.origin[keyPath: flow.cgPointIndex(.fixed)] = fixedTrackStart
-      newBounds = newBounds.integral
       newPositions.append(PositionedItem(bounds: newBounds, gridElement: positionedItem.gridElement))
     }
 


### PR DESCRIPTION
Removing this rounding aligns the behavior with SwiftUI's `HStack`. While in most cases this rounding does not have a significant impact, if the `Grid` has zero spacing there will become minor differences between the edges of each cell due to the differences between pixels and points. It's possible that rather than integer rounding we should be performing pixel rounding, but due to the alignment with `HStack` after this change, I'm proposing the easier option.

I created an example view controller that highlights the issue here: https://github.com/michaellindahl/Grid/tree/pixels-vs-points
Note that I created a checkerboard pattern of border that is present with the `HStack`, but with the `Grid` the border is not always visible (e.g. see the trailing border on the first cell which is hidden by the second cell overlapping it).
This becomes a bigger issue when looking at the last grid where the tall cell on the far right is on top and below it's neighbors on the left.

Before:
![WithIntegerRounding](https://github.com/exyte/Grid/assets/692663/e2c15684-b163-401b-b748-d12ce73262d8)

After:
![WithoutIntegerRounding](https://github.com/exyte/Grid/assets/692663/9e94f233-26d1-4bd5-8067-9d6bd71f2807)
