### PR TITLE
fix: global animation overrides animation in item views

### DIFF
--- a/Sources/View/Grid.swift
+++ b/Sources/View/Grid.swift
@@ -117,7 +117,6 @@ public struct Grid: View, LayoutArranging, LayoutPositioning {
             .alignmentGuide(.top, computeValue: { _ in self.topGuide(item: item) })
         }
       }
-      .animation(self.gridAnimation)
       .frame(
         flow: self.flow,
         size: mainGeometry.size,
@@ -128,11 +127,13 @@ public struct Grid: View, LayoutArranging, LayoutPositioning {
         ScrollView(self.scrollAxis) { content }
       }
       .onPreferenceChange(GridPreferenceKey.self) { preference in
-        self.calculateLayout(
-          preference: preference,
-          boundingSize: mainGeometry.size
-        )
-        self.saveAlignmentsFrom(preference: preference)
+        withAnimation(self.gridAnimation) {
+          self.calculateLayout(
+            preference: preference,
+            boundingSize: mainGeometry.size
+          )
+          self.saveAlignmentsFrom(preference: preference)
+        }
       }
     }
     .id(self.isLoaded)


### PR DESCRIPTION
The animation is set on the container view despite Apples recommendation to only apply an animation to leaf views. Any additional animations set on the leaf views (grid items in this case) is therefore ignored. But the animation for the grid should only happen when the layout of the grid items changes. 